### PR TITLE
Add interactive OS2 Produktcheckliste form with local save and JSON export

### DIFF
--- a/docs/checkliste-formular.md
+++ b/docs/checkliste-formular.md
@@ -1,0 +1,200 @@
+---
+title: OS2 Produktcheckliste (formular)
+nav_order: 2
+---
+
+# OS2 Produktcheckliste
+
+Udfyld status for hvert krav og tilføj dokumentation. Når du er færdig, kan du eksportere svarene til JSON.
+
+<div id="app"></div>
+
+<script>
+const kravData = {
+  relevans: [
+    ["R1","Løsningen skaber lokal værdi","sandkasse","Beskriv den konkrete værdi løsningen skaber i organisationen. F.eks. økonomisk, organisatorisk eller brugerrelateret."],
+    ["R2","Løsningen er accepteret af lokal linjeledelse","2","Beskriv eller henvis til en formel accept fra ledelse hos initiativtagerne til løsningen."],
+    ["R3","Løsningen har fælles offentligt potentiale","2","Redegør for hvordan løsningen kan bruges på tværs af kommuner og/eller offentlige myndigheder."],
+    ["R4","Ophæng til nationale strategier er til stede","3","Henvis til relevante strategier og forklar hvordan løsningen understøtter disse."]
+  ],
+  formkrav: [
+    ["F1","Alt kildekode til projektet udvikles synligt og aktivt i et repositorie og versionskontrolsystem, anvist af OS2","sandkasse","Upload al kildekode i et offentligt OS2 repository med aktiv versionshistorik."],
+    ["F2","Open Source licenskriterier overholdes","sandkasse","Angiv hvilken OSI-godkendt licens projektet bruger. OS2 standard er MPL 2.0"],
+    ["F3","Udbudsregler og alm. lovformlighed er overholdt","sandkasse","Bekræft at udbudspligt er overholdt eller redegør for undtagelse. Vedlæg evt. beslutningsnotat."],
+    ["F4","Der er tænkt på sikkerheden i løsningen","sandkasse","Beskriv hvordan sikkerhed er indtænkt i design, kode og drift – f.eks. kryptering, adgangsstyring."],
+    ["F5","Løsningens formål og værdi er beskrevet","sandkasse","Henvis til dokumentation (f.eks. README) hvor formål og målgruppe fremgår."],
+    ["F6","Kildekoden er overdraget og er placeret under OS2's kontrol","1","Bekræft og link til det officielle repository i OS2s versionskontrol."],
+    ["F7","Alt dokumentation til projektet udarbejdes med og overholder OS2s standardskabelon for dokumentation.","1","Brug OS2’s standard template til dokumentation. http://github.com/OS2offdig/os2-docs-template"],
+    ["F10","OS2's kommunikationskanaler anvendes (OS2.eu)","1","Bekræft og link til omtale på f.eks. os2.eu, nyhedsbrev eller andet."],
+    ["F11","Der anvendes offentlig issue-tracking anvist af OS2, hvor der tydeligt henvises til specifikke kodeændringer","1","Henvis til f.eks. Issues, hvor opgaver er koblet til pull-requests/commits."],
+    ["F12","Der er kun en version af core koden","2","Bekræft at der kun findes én ‘main’ version og at den er aktivt vedligeholdt."],
+    ["F13","Der er udarbejdet præsentationsmateriale af løsningen","2","Link til f.eks. slides, brochurer eller andet introduktionsmateriale."],
+    ["F14","Der er udarbejdet kommunikationsmateriale til strategisk niveau","2","F.eks. businesscase, one-pager til direktionsniveau og præsentation til udvalg."],
+    ["F15","Best practice for implementering i organisationen dokumenteres","2","Angiv implementeringsvejledning, erfaringsopsamling eller cases."],
+    ["F16","Teknisk dokumentation indeholder best practice for kodestandarder i forhold til de anvendte teknologier","2","Beskriv hvilke kodestandarder projektet følger. Evt. med links til eksterne guides og supplerende retningslinjer."],
+    ["F17","Drifts og vedligeholdelses setup er beskrevet","2","Redegør for driftspartner(e), ansvar og finansiering. Hvem drifter, hvem vedligeholder og hvem koordinerer."],
+    ["F18","Rammearkitekturen og standarder er fulgt og afvigelser er forklaret","2","Beskriv om/hvordan løsningen følger fællesoffentlig rammearkitektur – eller forklar hvorfor ikke."],
+    ["F19","Løsningen er leveret i et containerformat f.eks. docker (anbefaling)","2","Angiv om løsningen tilbydes i en containeriseret version som definerer hvordan applikationen bygges og køres."],
+    ["F20","Uddannelsesmateriale er udarbejdet (anbefaling)","2","Henvis til manual, brugervejledning eller andet brugerrelateret materiale."],
+    ["F21","Politisk kommunikation er udarbejdet (Lokal + Omverden)","3","Angiv indhold der kan bruges i politiske fora – f.eks. beslutningsoplæg eller pressemeddelelse."],
+    ["F22","Procesplan + procesansvar for driftsimplementering er udarbejdet","3","Tilføj en implementeringsplan med ‘hvem gør hvad hvornår’."],
+  ],
+  strategisk: [
+    ["S1","Produktet har en kobling til OS2's strategi","1","Beskriv hvordan produktet understøtter tværoffentlige behov, deling og fællesskab."],
+    ["S2","Løsningen understøtter innovation og open source","1","Angiv hvordan open source-værdier og nyskabelse er tænkt ind."],
+    ["S3","Produktets (forventlige) kobling til OS2's mission, vision og strategi er beskrevet","2","Angiv hvor produktet matcher med OS2's formål og indsatser."],
+    ["S4","Der er udarbejdet en vision og strategi for produktet","2","Beskriv produktvision og strategiske mål."],
+    ["S5","Produktets kobling til og overensstemmelse med OS2's vision og strategi er tilstede og beskrevet","3","Forklar hvordan løsningen passer ind i OS2’s overordnede værdisæt og visioner."],
+  ],
+  governance: [
+    ["G1","Produktet er oprettet i OS2's porteføljestyring","1","Produktet er oprettet på OS2s hjemmeside og indgår i årshjul."],
+    ["G2","Der koordineres løbende med OS2-sekretariatet","1","Bekræft, evt. med årshjul/datoer/mails for koordinering."],
+    ["G3","Der er udpeget en projektleder/tovholder","1","Navngiv og beskriv rolle og opgaver."],
+    ["G4","Bestyrelsen er orienteret","1","Vedlæg dokumentation for orientering."],
+    ["G5","Bestyrelsen har godkendt produktet","2","Vedlæg dokumentation for godkendelse."],
+    ["G6","Der er nedsat en styregruppe","2","Beskrivelse af styregruppen og roller/ansvar/opgaver."],
+    ["G7","Der er nedsat en koordinationsgruppe (anbefaling)","2","Beskrivelse af koordinationsgruppen og roller/ansvar/opgaver."],
+    ["G8","En projektmodel anvendes og er dokumenteret (anbefaling)","2","Beskiv den anvendte projektmodel eller metode."],
+    ["G9","Review af kode foretages af tredjepart (anbefaling)","2","Angiv hvilken ekstern part som udfører eller har udført review."],
+    ["G10","Der er udarbejdet en tilslutningserklæring til sikring af økonomi (anbefaling)","2","Vedlæg eller henvis til dokument for tilslutning og økonomi."],
+    ["G11","Bestyrelsen har godkendt styregruppen","3","Vedlæg dokumentation for beslutning."],
+    ["G12","Bestyrelsen er repræsenteret i styregruppen","3","Angiv hvilket medlem som deltager på vegne af bestyrelsen."],
+    ["G13","Der foreligger en aftale der sikrer økonomi til koordinering og videreudvikling","3","Vedlæg eller beskriv finansieringsaftalen."],
+    ["G14","Der er etableret et fagligt fællesskab bag løsningen hvor erfaringer kan udveksles","3","Henvis til brugerforum og/eller årshjul for aktiviteter."],
+  ]
+};
+
+const statusChoices = ["Ja", "Nej", "Ved ikke"];
+
+function sectionTitle(key) {
+  return ({ relevans: "Relevans", formkrav: "Formkrav", strategisk: "Strategisk sammenhæng", governance: "Governance" })[key] || key;
+}
+
+function render() {
+  const app = document.getElementById("app");
+  app.innerHTML = `
+    <style>
+      .meta{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px}
+      .meta input{width:100%}
+      table{width:100%;border-collapse:collapse;margin:16px 0;table-layout:fixed}
+      th,td{border:1px solid #ddd;padding:8px;vertical-align:top}
+      th{background:#f6f6f6}
+      th:nth-child(1), td:nth-child(1){width:6%}
+      th:nth-child(2), td:nth-child(2){width:19%}
+      th:nth-child(3), td:nth-child(3){width:10%}
+      th:nth-child(4), td:nth-child(4){width:27%}
+      th:nth-child(5), td:nth-child(5){width:12%}
+      th:nth-child(6), td:nth-child(6){width:26%}
+      select, textarea, input{width:100%}
+      textarea{min-height:96px}
+      .actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:16px}
+    </style>
+    <div class="meta">
+      <label>Produktnavn<input id="productName" placeholder="Fx OS2 Produkt X"></label>
+      <label>Udfyldt af<input id="filledBy" placeholder="Navn/organisation"></label>
+      <label>Dato<input id="filledDate" type="date"></label>
+    </div>
+    ${Object.entries(kravData).map(([section, rows]) => `
+      <h2>${sectionTitle(section)}</h2>
+      <table>
+        <thead><tr><th>#</th><th>Krav</th><th>Produktniveau</th><th>Retningslinjer</th><th>Efterlevet?</th><th>Dokumentation</th></tr></thead>
+        <tbody>
+          ${rows.map(([id, krav, niveau, guide]) => `
+            <tr>
+              <td>${id}</td>
+              <td>${krav}</td>
+              <td>${niveau}</td>
+              <td>${guide}</td>
+              <td>
+                <select data-id="${id}" data-field="status">
+                  <option value="">Vælg</option>
+                  ${statusChoices.map(s => `<option value="${s}">${s}</option>`).join("")}
+                </select>
+              </td>
+              <td><textarea data-id="${id}" data-field="dokumentation" placeholder="Tekst, links eller henvisninger"></textarea></td>
+            </tr>
+          `).join("")}
+        </tbody>
+      </table>
+    `).join("")}
+    <div class="actions">
+      <button id="saveLocal">Gem lokalt</button>
+      <button id="loadLocal">Indlæs lokalt</button>
+      <button id="exportJson">Eksportér JSON</button>
+    </div>
+  `;
+
+  document.getElementById("saveLocal").onclick = () => {
+    localStorage.setItem("os2ChecklistDraft", JSON.stringify(collectData()));
+    alert("Kladde gemt i browseren.");
+  };
+
+  document.getElementById("loadLocal").onclick = () => {
+    const raw = localStorage.getItem("os2ChecklistDraft");
+    if (!raw) return alert("Ingen gemt kladde fundet.");
+    populate(JSON.parse(raw));
+  };
+
+  document.getElementById("exportJson").onclick = () => {
+    const data = collectData();
+    const blob = new Blob([JSON.stringify(data, null, 2)], {type: "application/json"});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    const product = (data.productName || "os2-produkt").toLowerCase().replace(/\s+/g, "-");
+    a.href = url;
+    a.download = `${product}-checkliste.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+}
+
+function collectData() {
+  const result = {
+    productName: document.getElementById("productName").value,
+    filledBy: document.getElementById("filledBy").value,
+    filledDate: document.getElementById("filledDate").value,
+    generatedAt: new Date().toISOString(),
+    krav: []
+  };
+
+  document.querySelectorAll("select[data-id]").forEach(sel => {
+    const id = sel.dataset.id;
+    const doc = document.querySelector(`textarea[data-id='${id}']`);
+    const item = findRequirement(id);
+    result.krav.push({
+      id,
+      kategori: item.section,
+      krav: item.krav,
+      produktniveau: item.niveau,
+      retningslinjer: item.guide,
+      efterlevet: sel.value || null,
+      dokumentation: doc.value || ""
+    });
+  });
+  return result;
+}
+
+function populate(data) {
+  if (!data) return;
+  document.getElementById("productName").value = data.productName || "";
+  document.getElementById("filledBy").value = data.filledBy || "";
+  document.getElementById("filledDate").value = data.filledDate || "";
+  (data.krav || []).forEach(k => {
+    const sel = document.querySelector(`select[data-id='${k.id}']`);
+    const doc = document.querySelector(`textarea[data-id='${k.id}']`);
+    if (sel) sel.value = k.efterlevet || "";
+    if (doc) doc.value = k.dokumentation || "";
+  });
+}
+
+function findRequirement(id) {
+  for (const [section, rows] of Object.entries(kravData)) {
+    for (const [rid, krav, niveau, guide] of rows) {
+      if (rid === id) return { section, krav, niveau, guide };
+    }
+  }
+  return { section: "ukendt", krav: "", niveau: "", guide: "" };
+}
+
+render();
+</script>


### PR DESCRIPTION
### Motivation

- Provide a browser-based form for filling out the OS2 product checklist to make it easier to document compliance and supporting material.
- Allow users to persist drafts in the browser and export completed checklists as machine-readable JSON for exchange or storage.
- Centralize checklist requirement data in a single place to ensure consistent rendering across sections.

### Description

- Added a new documentation page `docs/checkliste-formular.md` that contains an interactive checklist UI and embedded `<script>` implementing the form.
- Introduced the `kravData` dataset to model checklist sections and rows and implemented rendering logic that builds tables per section and inputs for status and documentation.
- Implemented client-side helpers `collectData`, `populate`, and `findRequirement`, plus actions to save/load drafts to `localStorage` and to `exportJson` as a downloadable JSON file.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46aee058083258e0d1e800efc70f7)