### PR TITLE
Improve checklist form layout and collapsible behavior

### DIFF
--- a/docs/checkliste-formular.md
+++ b/docs/checkliste-formular.md
@@ -7,6 +7,7 @@ has_toc: false
 ---
 
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
 <div id="app" class="container-xl my-4 px-3 px-md-4"></div>
 
@@ -85,25 +86,48 @@ function render() {
       .checklist-table th:nth-child(6), .checklist-table td:nth-child(6){width:26%}
       .doc-textarea{min-height:110px}
     </style>
-    <div class="row g-3 mb-3">
-      <h1>OS2 selvevaluering</h1>
-      <p>Udfyld status for hvert krav og tilføj dokumentation. Når du er færdig, kan du eksportere svarene til JSON eller gemme direkte i et GitHub repo. Send JSON filen eller link til GitHub repo til sekretariatet på os2@os2.eu.</p>
+    <div class="row mb-3">
+      <div class="col-12">
+        <h1>OS2 selvevaluering</h1>
+        <p>Udfyld status for hvert krav og tilføj dokumentation. Når du er færdig, kan du eksportere svarene til JSON eller gemme direkte i et GitHub repo. Send JSON filen eller link til GitHub repo til sekretariatet på os2@os2.eu.</p>
+      </div>
     </div>
     <div class="row g-3 mb-3">
       <div class="col-12 col-md-4"><label class="form-label">Produktnavn</label><input class="form-control" id="productName" placeholder="Fx OS2 Produkt X"></div>
       <div class="col-12 col-md-4"><label class="form-label">Udfyldt af</label><input class="form-control" id="filledBy" placeholder="Navn/organisation"></div>
       <div class="col-12 col-md-4"><label class="form-label">Dato</label><input class="form-control" id="filledDate" type="date"></div>
     </div>
-    <div class="row g-3 mb-3"><div class="alert alert-info mb-0">
-      <div class="col-12">Valgfrit (ekspert): Udfyld GitHub-oplysninger for at gemme JSON direkte i repo under <code>docs/self-assessment/</code>.</div>
-      <div class="col-12 col-md-4"><label class="form-label">GitHub owner</label><input class="form-control" id="ghOwner" placeholder="fx OS2offdig"></div>
-      <div class="col-12 col-md-4"><label class="form-label">GitHub repo</label><input class="form-control" id="ghRepo" placeholder="fx os2-product-audits"></div>
-      <div class="col-12 col-md-4"><label class="form-label">Branch</label><input class="form-control" id="ghRef" value="main"></div>
-      <div class="col-12"><label class="form-label">GitHub token (fine-grained PAT med Actions:write + Contents:write)</label><input class="form-control" id="ghToken" type="password" placeholder="ghp_... (gemmes ikke automatisk)"></div>
-    </div></div>
-    ${Object.entries(kravData).map(([section, rows]) => `
-      <h2>${sectionTitle(section)}</h2>
-      <div class="table-responsive"><table class="table table-striped table-bordered align-top checklist-table">
+    <div class="accordion mb-3" id="githubAccordion">
+      <div class="accordion-item border-info">
+        <h2 class="accordion-header" id="headingGithub">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseGithub" aria-expanded="false" aria-controls="collapseGithub">
+            GitHub (for eksperten)
+          </button>
+        </h2>
+        <div id="collapseGithub" class="accordion-collapse collapse" aria-labelledby="headingGithub" data-bs-parent="#githubAccordion">
+          <div class="accordion-body alert alert-info mb-0">
+            <div class="row g-3">
+              <div class="col-12">Valgfrit: Udfyld GitHub-oplysninger for at gemme JSON direkte i repo under <code>docs/self-assessment/</code>.</div>
+              <div class="col-12 col-md-4"><label class="form-label">GitHub owner</label><input class="form-control" id="ghOwner" placeholder="fx OS2offdig"></div>
+              <div class="col-12 col-md-4"><label class="form-label">GitHub repo</label><input class="form-control" id="ghRepo" placeholder="fx os2-product-audits"></div>
+              <div class="col-12 col-md-4"><label class="form-label">Branch</label><input class="form-control" id="ghRef" value="main"></div>
+              <div class="col-12"><label class="form-label">GitHub token (fine-grained PAT med Actions:write + Contents:write)</label><input class="form-control" id="ghToken" type="password" placeholder="ghp_... (gemmes ikke automatisk)"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="accordion" id="sectionsAccordion">
+    ${Object.entries(kravData).map(([section, rows], idx) => `
+      <div class="accordion-item mb-2">
+      <h2 class="accordion-header" id="heading-${section}">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-${section}" aria-expanded="true" aria-controls="collapse-${section}">
+          ${sectionTitle(section)}
+        </button>
+      </h2>
+      <div id="collapse-${section}" class="accordion-collapse collapse show" aria-labelledby="heading-${section}" data-bs-parent="">
+      <div class="accordion-body">
+      <div class="table-responsive"><table class="table table-striped table-bordered align-top checklist-table mb-0">
         <thead><tr><th>#</th><th>Krav</th><th>Produktniveau</th><th>Retningslinjer</th><th>Efterlevet?</th><th>Dokumentation</th></tr></thead>
         <tbody>
           ${rows.map(([id, krav, niveau, guide]) => `
@@ -122,13 +146,14 @@ function render() {
             </tr>
           `).join("")}
         </tbody>
-      </table></div>
+      </table></div></div></div></div>
     `).join("")}
+    </div>
     <div class="d-flex gap-2 flex-wrap mt-3">
       <button class="btn btn-outline-secondary" id="saveLocal" type="button">Gem lokalt</button>
       <button class="btn btn-outline-secondary" id="loadLocal" type="button">Indlæs lokalt</button>
       <button class="btn btn-primary" id="exportJson" type="button">Eksportér JSON</button>
-      <button class="btn btn-success" id="saveGithub" type="button">Gem i GitHub</button>
+      <button class="btn btn-success d-none" id="saveGithub" type="button">Gem i GitHub</button>
     </div>
   `;
 
@@ -191,6 +216,16 @@ function render() {
     a.click();
     URL.revokeObjectURL(url);
   };
+
+  const ghFields = ["ghOwner", "ghRepo", "ghToken"];
+  const toggleSaveGithub = () => {
+    const show = ghFields.every(id => document.getElementById(id).value.trim());
+    document.getElementById("saveGithub").classList.toggle("d-none", !show);
+  };
+  ghFields.forEach(id => {
+    document.getElementById(id).addEventListener("input", toggleSaveGithub);
+  });
+  toggleSaveGithub();
 }
 
 function collectData() {


### PR DESCRIPTION
### Motivation
- Improve the page layout and UX so the checklist header uses the Bootstrap grid and optional inputs are hidden unless explicitly expanded. 
- Reduce clutter by hiding GitHub-specific fields behind an expert-only control and avoid showing a save-to-GitHub action unless credentials are provided. 

### Description
- Wrapped the H1 and intro paragraph in a full-width Bootstrap column (`row` + `col-12`) for proper grid layout in `docs/checkliste-formular.md`. 
- Moved the GitHub input fields into a collapsed accordion labeled `GitHub (for eksperten)` so they are only visible when expanded. 
- Converted each requirement section (Relevans, Formkrav, Strategisk sammenhæng, Governance) into individual Bootstrap accordion items that are open by default (`collapse show`). 
- Added the Bootstrap bundle JS include to enable accordion/collapse behavior and added logic to hide the `Gem i GitHub` button until `ghOwner`, `ghRepo`, and `ghToken` inputs are filled. 

### Testing
- Committed the changes to `docs/checkliste-formular.md` with `git commit` which succeeded. 
- Inspected the updated file with `nl -ba docs/checkliste-formular.md | sed -n '1,260p'` to verify the edits, which succeeded. 
- Created the PR metadata with the `make_pr` helper which returned the prepared title and body successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5033caf948325b5dd3725ec75de07)