### PR TITLE
Include Bootstrap JS and make GitHub save UI collapsible with conditional visibility

### DIFF
--- a/docs/checkliste-formular.md
+++ b/docs/checkliste-formular.md
@@ -7,6 +7,7 @@ has_toc: false
 ---
 
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
 <div id="app" class="container-xl my-4 px-3 px-md-4"></div>
 
@@ -85,22 +86,33 @@ function render() {
       .checklist-table th:nth-child(6), .checklist-table td:nth-child(6){width:26%}
       .doc-textarea{min-height:110px}
     </style>
-    <div class="row g-3 mb-3">
-      <h1>OS2 selvevaluering</h1>
-      <p>Udfyld status for hvert krav og tilføj dokumentation. Når du er færdig, kan du eksportere svarene til JSON eller gemme direkte i et GitHub repo. Send JSON filen eller link til GitHub repo til sekretariatet på os2@os2.eu.</p>
+    <div class="row mb-3">
+      <div class="col-12">
+        <h1>OS2 selvevaluering</h1>
+        <p>Udfyld status for hvert krav og tilføj dokumentation. Når du er færdig, kan du eksportere svarene til JSON eller gemme direkte i et GitHub repo. Send JSON filen eller link til GitHub repo til sekretariatet på os2@os2.eu.</p>
+      </div>
     </div>
     <div class="row g-3 mb-3">
       <div class="col-12 col-md-4"><label class="form-label">Produktnavn</label><input class="form-control" id="productName" placeholder="Fx OS2 Produkt X"></div>
       <div class="col-12 col-md-4"><label class="form-label">Udfyldt af</label><input class="form-control" id="filledBy" placeholder="Navn/organisation"></div>
       <div class="col-12 col-md-4"><label class="form-label">Dato</label><input class="form-control" id="filledDate" type="date"></div>
     </div>
-    <div class="row g-3 mb-3"><div class="alert alert-info mb-0">
-      <div class="col-12">Valgfrit (ekspert): Udfyld GitHub-oplysninger for at gemme JSON direkte i repo under <code>docs/self-assessment/</code>.</div>
-      <div class="col-12 col-md-4"><label class="form-label">GitHub owner</label><input class="form-control" id="ghOwner" placeholder="fx OS2offdig"></div>
-      <div class="col-12 col-md-4"><label class="form-label">GitHub repo</label><input class="form-control" id="ghRepo" placeholder="fx os2-product-audits"></div>
-      <div class="col-12 col-md-4"><label class="form-label">Branch</label><input class="form-control" id="ghRef" value="main"></div>
-      <div class="col-12"><label class="form-label">GitHub token (fine-grained PAT med Actions:write + Contents:write)</label><input class="form-control" id="ghToken" type="password" placeholder="ghp_... (gemmes ikke automatisk)"></div>
-    </div></div>
+    <div class="mb-3">
+      <div class="mb-2">
+        <button class="btn btn-link p-0 text-decoration-none" type="button" data-bs-toggle="collapse" data-bs-target="#collapseGithub" aria-expanded="false" aria-controls="collapseGithub">
+          GitHub (for eksperten)
+        </button>
+      </div>
+      <div id="collapseGithub" class="collapse">
+        <div class="row g-3">
+          <div class="col-12">Valgfrit: Udfyld GitHub-oplysninger for at gemme JSON direkte i repo under <code>docs/self-assessment/</code>.</div>
+          <div class="col-12 col-md-4"><label class="form-label">GitHub owner</label><input class="form-control" id="ghOwner" placeholder="fx OS2offdig"></div>
+          <div class="col-12 col-md-4"><label class="form-label">GitHub repo</label><input class="form-control" id="ghRepo" placeholder="fx os2-product-audits"></div>
+          <div class="col-12 col-md-4"><label class="form-label">Branch</label><input class="form-control" id="ghRef" value="main"></div>
+          <div class="col-12"><label class="form-label">GitHub token (fine-grained PAT med Actions:write + Contents:write)</label><input class="form-control" id="ghToken" type="password" placeholder="ghp_... (gemmes ikke automatisk)"></div>
+        </div>
+      </div>
+    </div>
     ${Object.entries(kravData).map(([section, rows]) => `
       <h2>${sectionTitle(section)}</h2>
       <div class="table-responsive"><table class="table table-striped table-bordered align-top checklist-table">
@@ -128,7 +140,7 @@ function render() {
       <button class="btn btn-outline-secondary" id="saveLocal" type="button">Gem lokalt</button>
       <button class="btn btn-outline-secondary" id="loadLocal" type="button">Indlæs lokalt</button>
       <button class="btn btn-primary" id="exportJson" type="button">Eksportér JSON</button>
-      <button class="btn btn-success" id="saveGithub" type="button">Gem i GitHub</button>
+      <button class="btn btn-success d-none" id="saveGithub" type="button">Gem i GitHub</button>
     </div>
   `;
 
@@ -191,6 +203,16 @@ function render() {
     a.click();
     URL.revokeObjectURL(url);
   };
+
+  const ghFields = ["ghOwner", "ghRepo", "ghToken"];
+  const toggleSaveGithub = () => {
+    const show = ghFields.every(id => document.getElementById(id).value.trim());
+    document.getElementById("saveGithub").classList.toggle("d-none", !show);
+  };
+  ghFields.forEach(id => {
+    document.getElementById(id).addEventListener("input", toggleSaveGithub);
+  });
+  toggleSaveGithub();
 }
 
 function collectData() {


### PR DESCRIPTION
### Motivation
- Ensure interactive Bootstrap components (collapse) function by loading the Bootstrap JS bundle. 
- Reduce UI clutter by hiding advanced GitHub save controls behind an expert toggle and only surface the save action when required fields are present. 

### Description
- Add the Bootstrap bundle script tag: `<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" ...></script>` to enable collapse behavior. 
- Rework the top layout markup to use a clearer `row`/`col-12` structure for the page header and spacing adjustments. 
- Move GitHub inputs into a collapsible panel and set the `#saveGithub` button to hidden by default (`d-none`), then add a `ghFields` array and `toggleSaveGithub` logic to show the button only when `ghOwner`, `ghRepo`, and `ghToken` are filled. 
- Minor UI cleanups such as adjusting `g-3` spacing and grouping elements for better responsiveness. 

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5033caf948325b5dd3725ec75de07)