### PR TITLE
Fix Mermaid pie chart block formatting in report generator

### DIFF
--- a/docs/rapportgenerator.md
+++ b/docs/rapportgenerator.md
@@ -171,20 +171,17 @@ async function generate() {
       {key: "yellow", value: b.yellow, color: "#FFFF00"},
       {key: "red", value: b.red, color: "#FF0000"}
     ].sort((a, c) => c.value - a.value);
-    const themeVars = `{"pie1": "${ranked[0].color}", "pie2": "${ranked[1].color}", "pie3": "${ranked[2].color}"}`;
+
     return `\`\`\`mermaid
-%%{init: {"themeVariables": ${themeVars}}}%%
+%%{init: {"themeVariables": {
+	"pie1": "${ranked[0].color}", "pie2": "${ranked[1].color}", "pie3": "${ranked[2].color}"
+}}}%%
 pie showData
-`+
-      `  title ${levelTitle} (${totalCount} krav)
-`+
-      `  "Grøn ${p(b.green)}%" : ${b.green}
-`+
-      `  "Gul ${p(b.yellow)}%"  : ${b.yellow}
-`+
-      `  "Rød ${p(b.red)}%"  : ${b.red}
-`+
-      "```";
+	title ${levelTitle} (${totalCount} krav)
+	"Grøn ${p(b.green)}%" : ${b.green}
+	"Gul ${p(b.yellow)}%" : ${b.yellow}
+	"Rød ${p(b.red)}%" : ${b.red}
+\`\`\``;
   }
 
   const dateVal = document.getElementById("reportDate").value || new Date().toISOString().slice(0,10).split("-").reverse().join("-");


### PR DESCRIPTION
### Motivation
- The report generator emitted Mermaid pie charts as concatenated single-line fragments which failed Mermaid's parser and produced incorrect diagrams.
- The output must be a real multiline Mermaid code block with an `init` section containing nested `themeVariables` and separate lines for `title` and each data row to render correctly.

### Description
- Updated the `mermaid()` helper in `docs/rapportgenerator.md` to build and return a true multiline triple-backtick Mermaid code block instead of concatenated string fragments. 
- Embedded the `themeVariables` object across multiple lines with `pie1`/`pie2`/`pie3` entries to match the expected Mermaid `init` structure. 
- Preserved the dynamic color ranking and percent calculation while normalizing line spacing for `title`, `Grøn`, `Gul`, and `Rød` rows so each appears on its own line.

### Testing
- Ran the replacement script that updated the `mermaid()` block and it completed successfully, producing the new multiline template string. 
- Inspected the updated `docs/rapportgenerator.md` and confirmed the generated Mermaid blocks appear as multiline code blocks around the `mermaid()` output (approx. lines 175–184). 
- Verified a diff of the file shows the expected formatting changes and created the PR with the new implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9991047748325a03cf3d414895403)